### PR TITLE
Added license field to package.json

### DIFF
--- a/smartclide-td-reusability-theia/package.json
+++ b/smartclide-td-reusability-theia/package.json
@@ -22,6 +22,7 @@
     "build": "tsc -b",
     "watch": "tsc -w"
   },
+  "license": "EPL-2.0",
   "theiaExtensions": [
     {
       "frontend": "lib/browser/smartclide-td-reusability-theia-frontend-module"


### PR DESCRIPTION
The absence of this field raises a warning during the building of a Che-Theia image.